### PR TITLE
Fixed bug in Compare.repeated_kfold

### DIFF
--- a/pychemauth/analysis/compare.py
+++ b/pychemauth/analysis/compare.py
@@ -853,6 +853,8 @@ class Compare:
 
         X_ = np.asarray(X)
         y_ = np.asarray(y)
+
+        groups_ = None
         if groups is not None:
             groups_ = np.asarray(groups)
 


### PR DESCRIPTION
Fixed an issue in Compare.repeated_kfold where the internal variable groups_ was not set if the keyword groups was equal to None. This caused a runtime error in rkf.split() for non-group repeated kfolds.